### PR TITLE
chore: add postgres schema and bullmq demo

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,3 +1,14 @@
 # ScratchBot Worker
 
 Placeholder for background job processor.
+
+## Local demo
+
+This package includes a simple BullMQ worker demonstrating a job
+transitioning from `pending` to `running` to `done` using an embedded Redis
+server.
+
+```sh
+npm install
+npm start
+```

--- a/apps/worker/index.js
+++ b/apps/worker/index.js
@@ -1,0 +1,28 @@
+const { Queue, Worker, QueueEvents } = require('bullmq');
+const { RedisServer } = require('@redis/server');
+
+(async () => {
+  // Start an embedded Redis server
+  const server = new RedisServer();
+  await server.open();
+  const connection = { host: '127.0.0.1', port: server.opts.port };
+
+  const queueName = 'demo';
+  const queue = new Queue(queueName, { connection });
+  const events = new QueueEvents(queueName, { connection });
+
+  events.on('waiting', ({ jobId }) => console.log(`pending ${jobId}`));
+  events.on('active', ({ jobId }) => console.log(`running ${jobId}`));
+  events.on('completed', ({ jobId }) => {
+    console.log(`done ${jobId}`);
+    server.close();
+    process.exit(0);
+  });
+
+  new Worker(queueName, async job => {
+    // Simulate work
+    return { ok: true };
+  }, { connection });
+
+  await queue.add('test', { hello: 'world' });
+})();

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "worker",
+  "version": "1.0.0",
+  "description": "Placeholder for background job processor.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@redis/server": "^1.0.0",
+    "bullmq": "^5.0.0"
+  }
+}

--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -10,6 +10,9 @@ services:
     depends_on:
       - postgres
       - redis
+    environment:
+      POSTGRES_URL: postgres://postgres:example@postgres:5432/postgres
+      REDIS_URL: redis://redis:6379
 
   worker:
     build:
@@ -18,6 +21,9 @@ services:
     depends_on:
       - postgres
       - redis
+    environment:
+      POSTGRES_URL: postgres://postgres:example@postgres:5432/postgres
+      REDIS_URL: redis://redis:6379
 
   ui:
     build:

--- a/infra/migrations/001_init.sql
+++ b/infra/migrations/001_init.sql
@@ -1,0 +1,57 @@
+-- Initial database schema for ScratchBot
+-- Tables: jobs, items, audits, commits, users, repos, installations
+
+CREATE TABLE installations (
+    id SERIAL PRIMARY KEY,
+    github_installation_id BIGINT UNIQUE NOT NULL,
+    account_login TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    github_user_id BIGINT UNIQUE NOT NULL,
+    login TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE repos (
+    id SERIAL PRIMARY KEY,
+    github_repo_id BIGINT UNIQUE NOT NULL,
+    full_name TEXT NOT NULL,
+    installation_id INTEGER REFERENCES installations(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE commits (
+    id SERIAL PRIMARY KEY,
+    repo_id INTEGER REFERENCES repos(id),
+    user_id INTEGER REFERENCES users(id),
+    sha TEXT UNIQUE NOT NULL,
+    message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE jobs (
+    id SERIAL PRIMARY KEY,
+    repo_id INTEGER REFERENCES repos(id),
+    user_id INTEGER REFERENCES users(id),
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE items (
+    id SERIAL PRIMARY KEY,
+    job_id INTEGER REFERENCES jobs(id),
+    path TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE audits (
+    id SERIAL PRIMARY KEY,
+    job_id INTEGER REFERENCES jobs(id),
+    action TEXT NOT NULL,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- define initial Postgres schema for installations, repos, jobs, items, commits, users and audits
- expose POSTGRES_URL/REDIS_URL to api and worker via docker compose
- add BullMQ worker demo with embedded Redis server

## Testing
- `npm install` *(fails: 403 Forbidden fetching packages)*
- `npm test` *(fails: Cannot find module 'bullmq')*
- `psql $POSTGRES_URL -c '\l'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c39b84d88333b05fc90dc9f25d57