### PR TITLE
feat: add planning helpers and slash command parsing

### DIFF
--- a/scratchbot/__init__.py
+++ b/scratchbot/__init__.py
@@ -2,10 +2,17 @@
 
 from .config import ScratchbotConfig
 from .git_ops import clone_pr_branch, commit_changes, verify_head_sha
+from .commands import parse_slash_command
+from .plan_builder import assemble_context
+from .plan_prompt import generate_docs_plan, PlanError
 
 __all__ = [
     "ScratchbotConfig",
     "clone_pr_branch",
     "commit_changes",
     "verify_head_sha",
+    "parse_slash_command",
+    "assemble_context",
+    "generate_docs_plan",
+    "PlanError",
 ]

--- a/scratchbot/commands.py
+++ b/scratchbot/commands.py
@@ -1,0 +1,29 @@
+"""Utilities for parsing ScratchBot slash commands."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+COMMAND_RE = re.compile(r"^/scratchbot\s+(apply|dismiss|mode)(?:\s+(.*))?", re.IGNORECASE)
+
+
+def parse_slash_command(body: str) -> Optional[Tuple[str, str]]:
+    """Parse a slash command from ``body``.
+
+    Parameters
+    ----------
+    body:
+        Full comment text.
+
+    Returns
+    -------
+    tuple | None
+        ``(command, args)`` if a slash command is present, otherwise ``None``.
+    """
+    match = COMMAND_RE.search(body.strip())
+    if not match:
+        return None
+    command = match.group(1).lower()
+    args = (match.group(2) or "").strip()
+    return command, args

--- a/scratchbot/github_api.py
+++ b/scratchbot/github_api.py
@@ -1,0 +1,52 @@
+"""Minimal GitHub API helpers used by ScratchBot."""
+
+from __future__ import annotations
+
+import requests
+from typing import Optional
+
+API_ROOT = "https://api.github.com"
+
+
+def _headers(token: str) -> dict:
+    return {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "scratchbot",
+    }
+
+
+def upsert_comment(repo: str, pr_number: int, body: str, token: str) -> None:
+    """Create or update the sticky Docs Plan comment on ``pr_number``."""
+    url = f"{API_ROOT}/repos/{repo}/issues/{pr_number}/comments"
+    headers = _headers(token)
+    resp = requests.get(url, headers=headers, timeout=10)
+    resp.raise_for_status()
+    existing = None
+    for comment in resp.json():
+        if comment.get("body", "").startswith("## \ud83d\udcda Docs Plan"):
+            existing = comment
+            break
+    if existing:
+        patch = requests.patch(
+            existing["url"], json={"body": body}, headers=headers, timeout=10
+        )
+        patch.raise_for_status()
+    else:
+        post = requests.post(url, json={"body": body}, headers=headers, timeout=10)
+        post.raise_for_status()
+
+
+def set_plan_status(repo: str, sha: str, state: str, token: str, description: Optional[str] = None, target_url: Optional[str] = None) -> None:
+    """Set ``scratchbot/plan`` status on ``sha``."""
+    url = f"{API_ROOT}/repos/{repo}/statuses/{sha}"
+    payload = {
+        "state": state,
+        "context": "scratchbot/plan",
+    }
+    if description:
+        payload["description"] = description
+    if target_url:
+        payload["target_url"] = target_url
+    resp = requests.post(url, json=payload, headers=_headers(token), timeout=10)
+    resp.raise_for_status()

--- a/scratchbot/plan_builder.py
+++ b/scratchbot/plan_builder.py
@@ -1,0 +1,82 @@
+"""Assemble context for documentation planning.
+
+This module provides utilities to collect a git diff, file tree, and
+symbol summaries for a repository.  The result is bounded by a token
+limit (approximate using whitespace separated words).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import ast
+import subprocess
+from typing import Dict, List
+
+TOKEN_LIMIT = 150_000
+
+
+@dataclass
+class FileSummary:
+    path: str
+    symbols: List[str]
+    loc: int
+
+
+def _token_count(text: str) -> int:
+    return len(text.split())
+
+
+def _python_symbols(path: Path) -> List[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    symbols: List[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if not node.name.startswith("_"):
+                symbols.append(node.name)
+    return symbols
+
+
+def build_file_summaries(repo: Path) -> List[FileSummary]:
+    summaries: List[FileSummary] = []
+    for file in repo.rglob("*.py"):
+        rel = file.relative_to(repo).as_posix()
+        text = file.read_text(encoding="utf-8")
+        symbols = _python_symbols(file)
+        loc = text.count("\n") + 1
+        summaries.append(FileSummary(path=rel, symbols=symbols, loc=loc))
+    return summaries
+
+
+def assemble_context(repo: str | Path, base_ref: str = "origin/main") -> Dict[str, object]:
+    """Return diff, tree, symbol summaries and token count for ``repo``.
+
+    Raises ``ValueError`` if the approximate token count exceeds
+    ``TOKEN_LIMIT``.
+    """
+    repo = Path(repo)
+    diff = subprocess.run(
+        ["git", "-C", str(repo), "diff", f"{base_ref}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    tree_lines = [p.as_posix() for p in sorted(repo.rglob("*")) if p.is_file()]
+    tree = "\n".join(tree_lines)
+
+    summaries = build_file_summaries(repo)
+    summaries_text = "\n".join(
+        f"{s.path}: {', '.join(s.symbols)}" for s in summaries
+    )
+
+    total_tokens = _token_count(diff) + _token_count(tree) + _token_count(summaries_text)
+    if total_tokens > TOKEN_LIMIT:
+        raise ValueError("context exceeds token limit")
+
+    return {
+        "diff": diff,
+        "file_tree": tree,
+        "summaries": summaries,
+        "tokens": total_tokens,
+    }

--- a/scratchbot/plan_prompt.py
+++ b/scratchbot/plan_prompt.py
@@ -1,0 +1,39 @@
+"""Generate documentation plan using a language model."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict, Any
+
+
+class PlanError(RuntimeError):
+    """Raised when the model output cannot be parsed."""
+
+
+def generate_docs_plan(context: Dict[str, Any], call_model: Callable[[str], str]) -> Dict[str, Any]:
+    """Call ``call_model`` with a prompt derived from ``context``.
+
+    The callable must accept a single string prompt and return the model's
+    raw text response. The response is parsed as JSON with ``missing`` and
+    ``needs_update`` lists.
+    """
+    prompt = (
+        "You are ScratchBot. Given the diff, file tree and symbol summaries, "
+        "produce a JSON object with keys 'missing' and 'needs_update'."\
+    )
+    prompt += "\nDiff:\n" + context["diff"]
+    prompt += "\nFile Tree:\n" + context["file_tree"]
+    prompt += "\nSymbols:\n" + ", ".join(
+        f"{s.path}: {', '.join(s.symbols)}" for s in context.get("summaries", [])
+    )
+
+    raw = call_model(prompt)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PlanError("model did not return valid JSON") from exc
+    if not {"missing", "needs_update"} <= data.keys():
+        raise PlanError("JSON must contain missing and needs_update")
+    if not isinstance(data["missing"], list) or not isinstance(data["needs_update"], list):
+        raise PlanError("missing and needs_update must be lists")
+    return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,17 @@
+from scratchbot.commands import parse_slash_command
+
+
+def test_parse_apply():
+    assert parse_slash_command("/scratchbot apply all") == ("apply", "all")
+
+
+def test_parse_dismiss():
+    assert parse_slash_command("/scratchbot dismiss") == ("dismiss", "")
+
+
+def test_parse_mode():
+    assert parse_slash_command("/scratchbot mode batch") == ("mode", "batch")
+
+
+def test_parse_none():
+    assert parse_slash_command("hello") is None


### PR DESCRIPTION
## Summary
- add plan context builder and model-driven planning helper
- support parsing `/scratchbot` slash commands
- include GitHub helpers for comments and status updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c56c75d083339c382cffa7bfa6ce