### PR TITLE
feat: add TypeScript dependency for ts parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Scratchbot
+
+This repository includes a Node-based TypeScript parser located at `scratchbot/ts_parser.js`.
+
+## Installation
+
+Install the JavaScript dependencies:
+
+```bash
+npm install
+```
+
+After installation, you can run the parser directly:
+
+```bash
+node scratchbot/ts_parser.js path/to/file.ts
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "scratchbot",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node scratchbot/ts_parser.js scratchbot/ts_parser.js >/dev/null"
+  },
+  "dependencies": {
+    "typescript": "^5.4.5"
+  }
+}


### PR DESCRIPTION
## Summary
- add root package.json with TypeScript dependency and test script
- document how to install and run the TypeScript parser

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)*
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6896d2efb1c08333b4f338bfcce0c672