### PR TITLE
feat(cli): add scratchbot command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,3 +1,16 @@
 # ScratchBot CLI
 
-Placeholder for command-line interface.
+Command line interface for running ScratchBot helpers.
+
+## Usage
+
+Install dependencies and use the `scratchbot` command:
+
+```bash
+scratchbot analyze [path]
+scratchbot plan [path]
+scratchbot apply [...args]
+```
+
+Each subcommand forwards to the corresponding Python module under the
+`scratchbot` package.

--- a/packages/cli/dist/cli.js
+++ b/packages/cli/dist/cli.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+
+function runPython(mod, args) {
+  const child = spawn('python', ['-m', `scratchbot.${mod}`, ...args], { stdio: 'inherit' });
+  child.on('close', (code) => {
+    process.exit(code ?? 0);
+  });
+}
+
+const [command, ...rest] = process.argv.slice(2);
+
+switch (command) {
+  case 'analyze':
+    runPython('analyze', rest);
+    break;
+  case 'plan':
+    runPython('plan_builder', rest);
+    break;
+  case 'apply':
+    runPython('git_ops', rest);
+    break;
+  default:
+    console.error('Usage: scratchbot <analyze|plan|apply> [args...]');
+    process.exit(1);
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,8 +1,12 @@
 {
   "name": "scratchbot-cli",
   "version": "0.0.0",
+  "bin": {
+    "scratchbot": "dist/cli.js"
+  },
   "scripts": {
     "register-app": "node register-app.js",
+    "build": "tsc src/cli.ts --outDir dist",
     "test": "echo \"No tests\""
   },
   "dependencies": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+
+function runPython(mod: string, args: string[]): void {
+  const child = spawn('python', ['-m', `scratchbot.${mod}`, ...args], { stdio: 'inherit' });
+  child.on('close', (code: number | null) => {
+    process.exit(code ?? 0);
+  });
+}
+
+const [command, ...rest] = process.argv.slice(2);
+
+switch (command) {
+  case 'analyze':
+    runPython('analyze', rest);
+    break;
+  case 'plan':
+    runPython('plan_builder', rest);
+    break;
+  case 'apply':
+    runPython('git_ops', rest);
+    break;
+  default:
+    console.error('Usage: scratchbot <analyze|plan|apply> [args...]');
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary
- expose scratchbot CLI with analyze/plan/apply subcommands that proxy to Python
- document command usage in README
- register CLI via package.json bin entry

## Testing
- `npm test --prefix packages/cli`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896d2f1c8d48333946135d9e36614b1