### PR TITLE
feat: add openai helper

### DIFF
--- a/scratchbot/plan_prompt.py
+++ b/scratchbot/plan_prompt.py
@@ -1,8 +1,17 @@
-"""Generate documentation plan using a language model."""
+"""Generate documentation plan using a language model.
+
+The module exposes :func:`call_openai` which can either invoke a real OpenAI
+model or return stubbed JSON for deterministic tests. If the environment
+variable ``SCRATCHBOT_PLAN_JSON`` points to a file, its contents are returned
+instead of contacting the API. Otherwise the ``openai`` package is used with
+the API key in ``OPENAI_API_KEY``.
+"""
 
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from typing import Callable, Dict, Any
 
 
@@ -10,13 +19,46 @@ class PlanError(RuntimeError):
     """Raised when the model output cannot be parsed."""
 
 
-def generate_docs_plan(context: Dict[str, Any], call_model: Callable[[str], str]) -> Dict[str, Any]:
+def call_openai(prompt: str) -> str:
+    """Return model output for ``prompt``.
+
+    ``SCRATCHBOT_PLAN_JSON`` may point to a JSON file used for deterministic
+    testing. When unset, the function attempts to call the real OpenAI API
+    using the ``openai`` package. Set ``OPENAI_API_KEY`` and optionally
+    ``OPENAI_MODEL`` to choose the model name.
+    """
+
+    stub_path = os.environ.get("SCRATCHBOT_PLAN_JSON")
+    if stub_path:
+        return Path(stub_path).read_text(encoding="utf-8")
+
+    try:
+        from openai import OpenAI  # type: ignore
+    except Exception as exc:  # pragma: no cover - requires optional dep
+        raise RuntimeError(
+            "openai package not installed; set SCRATCHBOT_PLAN_JSON for tests"
+        ) from exc
+
+    client = OpenAI()
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+    response = client.responses.create(model=model, input=prompt)
+    return response.output_text
+
+
+def generate_docs_plan(
+    context: Dict[str, Any],
+    call_model: Callable[[str], str] | None = None,
+) -> Dict[str, Any]:
     """Call ``call_model`` with a prompt derived from ``context``.
 
-    The callable must accept a single string prompt and return the model's
-    raw text response. The response is parsed as JSON with ``missing`` and
-    ``needs_update`` lists.
+    ``call_model`` defaults to :func:`call_openai`. The callable must accept a
+    single string prompt and return the model's raw text response. The response
+    is parsed as JSON with ``missing`` and ``needs_update`` lists.
     """
+
+    if call_model is None:
+        call_model = call_openai
+
     prompt = (
         "You are ScratchBot. Given the diff, file tree and symbol summaries, "
         "produce a JSON object with keys 'missing' and 'needs_update'."\

--- a/tests/test_plan_prompt.py
+++ b/tests/test_plan_prompt.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+import sys
+
 from scratchbot.plan_prompt import call_openai, generate_docs_plan
 
 
@@ -6,6 +9,26 @@ def test_call_openai_stub(tmp_path, monkeypatch):
     stub.write_text('{"missing": [], "needs_update": []}')
     monkeypatch.setenv("SCRATCHBOT_PLAN_JSON", str(stub))
     assert call_openai("prompt") == stub.read_text()
+
+
+def test_call_openai_defaults_to_gpt5(monkeypatch):
+    capture = {}
+
+    class DummyResponses:
+        def create(self, model, input):
+            capture["model"] = model
+            capture["input"] = input
+            return SimpleNamespace(output_text="ok")
+
+    class DummyClient:
+        def __init__(self):
+            self.responses = DummyResponses()
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=DummyClient))
+    monkeypatch.delenv("SCRATCHBOT_PLAN_JSON", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    assert call_openai("hi") == "ok"
+    assert capture["model"] == "gpt-5"
 
 
 def test_generate_docs_plan_defaults_to_call_openai(tmp_path, monkeypatch):

--- a/tests/test_plan_prompt.py
+++ b/tests/test_plan_prompt.py
@@ -1,0 +1,16 @@
+from scratchbot.plan_prompt import call_openai, generate_docs_plan
+
+
+def test_call_openai_stub(tmp_path, monkeypatch):
+    stub = tmp_path / "stub.json"
+    stub.write_text('{"missing": [], "needs_update": []}')
+    monkeypatch.setenv("SCRATCHBOT_PLAN_JSON", str(stub))
+    assert call_openai("prompt") == stub.read_text()
+
+
+def test_generate_docs_plan_defaults_to_call_openai(tmp_path, monkeypatch):
+    stub = tmp_path / "stub.json"
+    stub.write_text('{"missing": ["a"], "needs_update": []}')
+    monkeypatch.setenv("SCRATCHBOT_PLAN_JSON", str(stub))
+    context = {"diff": "", "file_tree": "", "summaries": []}
+    assert generate_docs_plan(context) == {"missing": ["a"], "needs_update": []}


### PR DESCRIPTION
## Summary
- add `call_openai` helper that can read a stubbed JSON response or hit the OpenAI API
- default `generate_docs_plan` to the helper and document swapping mocks vs. real models
- cover helper with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d2f6605c8333b4dee71a2c4f4051